### PR TITLE
Prevent crash when invoking pdfforms without a subcommand

### DIFF
--- a/pdfforms/pdfforms.py
+++ b/pdfforms/pdfforms.py
@@ -138,7 +138,9 @@ def make_path(prefix):
 
 def parse_cli(*args):
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(title="subcommands", dest="subcommand")
+    # TODO: Make this a parameter of add_subparsers() in Python 3.7+
+    subparsers.required = True
 
     inspect = subparsers.add_parser("inspect")
     inspect.set_defaults(func=inspect_pdfs)

--- a/pdfforms/pdfforms.py
+++ b/pdfforms/pdfforms.py
@@ -137,7 +137,7 @@ def make_path(prefix):
 
 
 def parse_cli(*args):
-    parser = argparse.ArgumentParser(prog="forms")
+    parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 
     inspect = subparsers.add_parser("inspect")


### PR DESCRIPTION
Previously, this raised an exception:

    AttributeError: 'Namespace' object has no attribute 'func'

Now, this will show a usage error message:

    usage: pdfforms [-h] {inspect,fill} ...
    pdfforms: error: the following arguments are required: subcommand

Relevant Python issue:

* https://bugs.python.org/issue16308
